### PR TITLE
Properly pass :path argument to quicklisp-quickstart:install.

### DIFF
--- a/CHANGES.mess
+++ b/CHANGES.mess
@@ -30,6 +30,8 @@ A big thanks to everyone for trying it out and reporting problems!
 - Add a race stats panel, accessible via the cheat ``how fast am i``
 - Change the ending stats panel to "X / Y" secrets found
   Suggested by HaltingState
+- Properly pass :path argument to quicklisp-quickstart:install.
+  Suggested by Tim Van den Langenbergh
 
 ## 1.0.0
 - Fix price of Rubber Duck

--- a/install.lisp
+++ b/install.lisp
@@ -24,6 +24,8 @@ exec sbcl --dynamic-space-size 4GB --noinform --no-sysinit --no-userinit --load 
   (:export #:install))
 (in-package #:org.shirakumo.fraf.kandria.install)
 
+(declaim (optimize (debug 3)))
+
 (defvar *kandria-root* #.(make-pathname :name NIL :type NIL :defaults (or *load-pathname* (error "This file must be LOADed."))))
 
 (defun call-with-connection (function host port)
@@ -75,10 +77,10 @@ exec sbcl --dynamic-space-size 4GB --noinform --no-sysinit --no-userinit --load 
              (load output)
           (delete-file output))))))
 
-(defun install-quicklisp (&rest args)
+(defun install-quicklisp (&key (path #P""))
   (unless (find-package 'quicklisp-quickstart)
     (load-quicklisp-quickstart))
-  (f quicklisp-quickstart install args))
+  (f quicklisp-quickstart install :path path))
 
 (defun status (format &rest args)
   (format *query-io* "; ~?~%" format args))


### PR DESCRIPTION
Passing the arguments to install-quicklisp to the f macro, when both install-quicklisp and f take &amp;rest arguments results in improper destructuring, turning the passed :path path parameters into (:path path).

Description of the proposed changes

Please check:
- [x] I have read the CONTRIBUTING.mess document
- [x] I accept the terms of the Base License Agreement therein
- [x] I have added my name and a summary of the changes to the changelog
