### PR TITLE
Updated with-mesh-construction as per new syntax.

### DIFF
--- a/CHANGES.mess
+++ b/CHANGES.mess
@@ -9,6 +9,8 @@ A big thanks to everyone for trying it out and reporting problems!
 - Fix a minor typo in the German translation
   Committed by Jan Moringen
 - set executable flag for install.lisp and setup.lisp so the README works
+- Updated with-mesh-reconstruction macro call to be consistent with its changed syntax in Trial (as of commit ba1c063).
+  Committed by Pranav Vats
 
 ## 1.1.15
 - Fix a crash when a toast is displayed while the map is being closed

--- a/ui/main-menu.lisp
+++ b/ui/main-menu.lisp
@@ -179,7 +179,7 @@ void main(){
 }")
 
 (define-asset (kandria wave-grid) mesh
-    (with-mesh-construction (v finalize (location uv normal) NIL)
+    (with-mesh-construction (v :finalizer finalize :attributes (location uv normal) :deduplicate NIL)
       (let* ((s (/ 512 64))
              (s2 (/ s -2)))
         (dotimes (x s (finalize-data))


### PR DESCRIPTION
Syntax for with-mesh-construction was changed in Trial (commit: ba1c063a930f2654ff806efff7f04b60f1fa696f).

Fixes Issue #21 

Please check:
- [x] I have read the CONTRIBUTING.mess document
- [x] I accept the terms of the Base License Agreement therein
- [x] I have added my name and a summary of the changes to the changelog
